### PR TITLE
develop sc

### DIFF
--- a/bot-logic/behaviour_hw_test.c
+++ b/bot-logic/behaviour_hw_test.c
@@ -43,8 +43,8 @@ static uint8_t testmode =
 #else
 	3
 #endif // TEST_X
-	; /**< Testmodus, 0: analog, 1: digital, 2: Motor */
-static uint16_t calls = 0; /**< Anzahl der Durchlaeufe fuer Motor-Test */
+	; /** < Testmodus, 0: analog, 1: digital, 2: Motor */
+static uint16_t calls = 0; /** < Anzahl der Durchlaeufe fuer Motor-Test */
 
 /**
  * Das Testverhalten

--- a/ct-Bot.h
+++ b/ct-Bot.h
@@ -30,64 +30,64 @@
  * Module switches, to make code smaller if features are not needed *
  ********************************************************************/
 
-//#define LOG_CTSIM_AVAILABLE			/**< Logging zum ct-Sim (PC und MCU) */
-//#define LOG_DISPLAY_AVAILABLE			/**< Logging ueber das LCD-Display (PC und MCU) */
-//#define LOG_UART_AVAILABLE			/**< Logging ueber UART (nur fuer MCU) */
-#define LOG_STDOUT_AVAILABLE 			/**< Logging auf die Konsole (nur fuer PC) */
-//#define LOG_MMC_AVAILABLE				/**< Logging in eine txt-Datei auf MMC */
-#define USE_MINILOG						/**< schaltet auf schlankes Logging um */
-//#define CREATE_TRACEFILE_AVAILABLE	/**< Aktiviert das Schreiben einer Trace-Datei (nur PC) */
+#define LOG_CTSIM_AVAILABLE					/** < Logging zum ct-Sim (PC und MCU) */
+//#define LOG_DISPLAY_AVAILABLE				/** < Logging ueber das LCD-Display (PC und MCU) */
+#define LOG_UART_AVAILABLE					/** < Logging ueber UART (nur fuer MCU) */
+#define LOG_STDOUT_AVAILABLE 				/** < Logging auf die Konsole (nur fuer PC) */
+//#define LOG_MMC_AVAILABLE					/** < Logging in eine txt-Datei auf MMC */
+#define USE_MINILOG							/** < schaltet auf schlankes Logging um */
+//#define CREATE_TRACEFILE_AVAILABLE		/** < Aktiviert das Schreiben einer Trace-Datei (nur PC) */
 
-#define LED_AVAILABLE					/**< LEDs aktiv */
-#define IR_AVAILABLE					/**< Infrarot Fernbedienung aktiv */
-#define RC5_AVAILABLE					/**< Key-Mapping fuer IR-RC aktiv */
-#define KEYPAD_AVAILABLE				/**< Keypad-Eingabe vorhanden? */
+#define LED_AVAILABLE						/** < LEDs aktiv */
+#define IR_AVAILABLE						/** < Infrarot Fernbedienung aktiv */
+#define RC5_AVAILABLE						/** < Key-Mapping fuer IR-RC aktiv */
+#define KEYPAD_AVAILABLE					/** < Keypad-Eingabe vorhanden? */
 
-#define BOT_2_SIM_AVAILABLE				/**< Soll der Bot mit dem Sim kommunizieren? */
-//#define BOT_2_BOT_AVAILABLE			/**< Sollen Bots untereinander kommunizieren? */
-#define BOT_2_BOT_PAYLOAD_AVAILABLE		/**< Aktiviert Payload-Versand per Bot-2-Bot Kommunikation */
+#define BOT_2_SIM_AVAILABLE					/** < Soll der Bot mit dem Sim kommunizieren? */
+//#define BOT_2_BOT_AVAILABLE				/** < Sollen Bots untereinander kommunizieren? */
+#define BOT_2_BOT_PAYLOAD_AVAILABLE			/** < Aktiviert Payload-Versand per Bot-2-Bot Kommunikation */
 
-#define DISPLAY_AVAILABLE				/**< Display aktiv */
-#define DISPLAY_REMOTE_AVAILABLE		/**< Sende LCD Anzeigedaten an den Simulator */
-//#define WELCOME_AVAILABLE				/**< kleiner Willkommensgruss */
+#define DISPLAY_AVAILABLE					/** < Display aktiv */
+#define DISPLAY_REMOTE_AVAILABLE			/** < Sende LCD Anzeigedaten an den Simulator */
+//#define WELCOME_AVAILABLE					/** < kleiner Willkommensgruss */
 
-//#define MOUSE_AVAILABLE				/**< Maus Sensor */
-#define MEASURE_MOUSE_AVAILABLE			/**< Geschwindigkeiten werden aus den Maussensordaten berechnet */
-//#define MEASURE_COUPLED_AVAILABLE		/**< Geschwindigkeiten werden aus Maus- und Encoderwerten ermittelt und gekoppelt */
-//#define MEASURE_POSITION_ERRORS_AVAILABLE	/**< Fehlerberechnungen bei der Positionsbestimmung */
+//#define MOUSE_AVAILABLE					/** < Maus Sensor */
+#define MEASURE_MOUSE_AVAILABLE				/** < Geschwindigkeiten werden aus den Maussensordaten berechnet */
+//#define MEASURE_COUPLED_AVAILABLE			/** < Geschwindigkeiten werden aus Maus- und Encoderwerten ermittelt und gekoppelt */
+//#define MEASURE_POSITION_ERRORS_AVAILABLE	/** < Fehlerberechnungen bei der Positionsbestimmung */
 
-//#define BPS_AVAILABLE			/**< Bot Positioning System */
+//#define BPS_AVAILABLE						/** < Bot Positioning System */
 
-#define ADC_AVAILABLE			/**< A/D-Konverter */
-#define ENA_AVAILABLE			/**< Enable-Leitungen */
-#define SHIFT_AVAILABLE			/**< Shift Register */
+#define ADC_AVAILABLE						/** < A/D-Konverter */
+#define ENA_AVAILABLE						/** < Enable-Leitungen */
+#define SHIFT_AVAILABLE						/** < Shift Register */
 
-#define BEHAVIOUR_AVAILABLE		/**< Nur wenn dieser Parameter gesetzt ist, exisitiert das Verhaltenssystem */
+#define BEHAVIOUR_AVAILABLE					/** < Nur wenn dieser Parameter gesetzt ist, exisitiert das Verhaltenssystem */
 
-#define POS_STORE_AVAILABLE		/**< Positionsspeicher vorhanden */
+#define POS_STORE_AVAILABLE					/** < Positionsspeicher vorhanden */
 
-//#define MAP_AVAILABLE			/**< Aktiviert die Kartographie */
-#define MAP_2_SIM_AVAILABLE		/**< Sendet die Map zur Anzeige an den Sim */
+//#define MAP_AVAILABLE						/** < Aktiviert die Kartographie */
+#define MAP_2_SIM_AVAILABLE					/** < Sendet die Map zur Anzeige an den Sim */
 
-//#define MMC_AVAILABLE			/**< haben wir eine MMC/SD-Karte zur Verfuegung? */
-//#define MMC_VM_AVAILABLE		/**< Virtual Memory Management mit MMC / SD-Card oder PC-Emulation */
-#define BOT_FS_AVAILABLE		/**< Aktiviert das Dateisystem BotFS (auf MCU nur mit MMC moeglich) */
-#define OS_AVAILABLE			/**< Aktiviert BotOS fuer Threads und Scheduling */
+//#define MMC_AVAILABLE						/** < haben wir eine MMC/SD-Karte zur Verfuegung? */
+//#define MMC_VM_AVAILABLE					/** < Virtual Memory Management mit MMC / SD-Card oder PC-Emulation */
+#define BOT_FS_AVAILABLE					/** < Aktiviert das Dateisystem BotFS (auf MCU nur mit MMC moeglich) */
+#define OS_AVAILABLE						/** < Aktiviert BotOS fuer Threads und Scheduling */
 
-#define SPEED_CONTROL_AVAILABLE /**< Aktiviert die Motorregelung */
-//#define ADJUST_PID_PARAMS		/**< macht PID-Paramter zur Laufzeit per FB einstellbar */
-//#define SPEED_LOG_AVAILABLE 	/**< Zeichnet Debug-Infos der Motorregelung auf MMC auf */
+#define SPEED_CONTROL_AVAILABLE 			/** < Aktiviert die Motorregelung */
+//#define ADJUST_PID_PARAMS					/** < macht PID-Paramter zur Laufzeit per FB einstellbar */
+//#define SPEED_LOG_AVAILABLE 				/** < Zeichnet Debug-Infos der Motorregelung auf MMC auf */
 
-//#define SRF10_AVAILABLE		/**< Ultraschallsensor SRF10 vorhanden */
-//#define CMPS03_AVAILABLE		/**< Kompass CMPS03 vorhanden */
-//#define SP03_AVAILABLE		/**< Sprachmodul SP03 vorhanden */
+//#define SRF10_AVAILABLE					/** < Ultraschallsensor SRF10 vorhanden */
+//#define CMPS03_AVAILABLE					/** < Kompass CMPS03 vorhanden */
+//#define SP03_AVAILABLE					/** < Sprachmodul SP03 vorhanden */
 
-#define ARM_LINUX_BOARD			/**< Code fuer ARM-Linux Board aktivieren, wenn ein ARM-Linux-* Target ausgewaehlt wurde. Fuehrt den high-level Code und die Verhalten aus */
-//#define BOT_2_RPI_AVAILABLE	/**< Kommunikation von ATmega mit einem Linux-Board (z.B. Rapsberry Pi) aktivieren. Fuehrt auf dem ATmega den low-level Code aus */
+#define ARM_LINUX_BOARD						/** < Code fuer ARM-Linux Board aktivieren, wenn ein ARM-Linux-* Target ausgewaehlt wurde. Fuehrt den high-level Code und die Verhalten aus */
+//#define BOT_2_RPI_AVAILABLE				/** < Kommunikation von ATmega mit einem Linux-Board (z.B. Rapsberry Pi) aktivieren. Fuehrt auf dem ATmega den low-level Code aus */
 
-//#define EEPROM_EMU_AVAILABLE	/**< Aktiviert die EEPROM-Emulation fuer PC, siehe Hinweise in pc/eeprom_pc.c */
+//#define EEPROM_EMU_AVAILABLE				/** < Aktiviert die EEPROM-Emulation fuer PC, siehe Hinweise in pc/eeprom_pc.c */
 
-//#define BOOTLOADER_AVAILABLE	/**< Aktiviert den Bootloadercode - das ist nur noetig fuer die einmalige "Installation" des Bootloaders */
+//#define BOOTLOADER_AVAILABLE				/** < Aktiviert den Bootloadercode - das ist nur noetig fuer die einmalige "Installation" des Bootloaders */
 
 /************************************************************
  * Some Dependencies!!!
@@ -142,7 +142,7 @@
 #define BOT_2_SIM_AVAILABLE // simulierte Bots brauchen immer Kommunikation zum Sim
 #endif
 
-#define COMMAND_AVAILABLE /**< High-Level Kommunikation */
+#define COMMAND_AVAILABLE /** < High-Level Kommunikation */
 #endif // PC
 
 #ifdef MCU
@@ -164,8 +164,8 @@
 #endif // MCU && BOT_2_RPI_AVAILABLE
 
 #ifdef BOT_2_SIM_AVAILABLE
-#define UART_AVAILABLE		/**< Serielle Kommunikation */
-#define COMMAND_AVAILABLE	/**< High-Level Communication */
+#define UART_AVAILABLE		/** < Serielle Kommunikation */
+#define COMMAND_AVAILABLE	/** < High-Level Communication */
 #else // ! BOT_2_SIM_AVAILABLE
 #undef DISPLAY_REMOTE_AVAILABLE
 #undef MAP_2_SIM_AVAILABLE
@@ -209,25 +209,25 @@
 
 #ifdef LOG_UART_AVAILABLE
 #undef USE_MINILOG
-#define LOG_AVAILABLE /**< LOG aktiv? */
+#define LOG_AVAILABLE /** < LOG aktiv? */
 #endif
 
 #ifdef LOG_CTSIM_AVAILABLE
-#define LOG_AVAILABLE /**< LOG aktiv? */
+#define LOG_AVAILABLE /** < LOG aktiv? */
 #endif
 
 #ifdef LOG_DISPLAY_AVAILABLE
 #undef USE_MINILOG
-#define LOG_AVAILABLE /**< LOG aktiv? */
+#define LOG_AVAILABLE /** < LOG aktiv? */
 #endif
 
 #ifdef LOG_STDOUT_AVAILABLE
 #undef USE_MINILOG
-#define LOG_AVAILABLE /**< LOG aktiv? */
+#define LOG_AVAILABLE /** < LOG aktiv? */
 #endif
 
 #ifdef LOG_MMC_AVAILABLE
-#define LOG_AVAILABLE /**< LOG aktiv? */
+#define LOG_AVAILABLE /** < LOG aktiv? */
 #endif
 
 #ifndef BEHAVIOUR_AVAILABLE
@@ -274,7 +274,7 @@
 
 	/* Es kann immer nur ueber eine Schnittstelle geloggt werden. */
 #ifdef LOG_UART_AVAILABLE
-#define UART_AVAILABLE /**< Serielle Kommunikation */
+#define UART_AVAILABLE /** < Serielle Kommunikation */
 #undef LOG_CTSIM_AVAILABLE
 #undef LOG_DISPLAY_AVAILABLE
 #undef LOG_STDOUT_AVAILABLE
@@ -310,19 +310,19 @@
 
 
 #ifdef SRF10_AVAILABLE
-#define TWI_AVAILABLE /**< TWI-Schnittstelle (I2C) */
+#define TWI_AVAILABLE /** < TWI-Schnittstelle (I2C) */
 #endif
 
 #ifdef CMPS03_AVAILABLE
-#define I2C_AVAILABLE /**< I2C-Treiber */
+#define I2C_AVAILABLE /** < I2C-Treiber */
 #endif
 
 #ifdef SP03_AVAILABLE
-#define I2C_AVAILABLE /**< I2C-Treiber */
+#define I2C_AVAILABLE /** < I2C-Treiber */
 #endif
 
 #ifdef TWI_AVAILABLE
-#define I2C_AVAILABLE /**< I2C-Treiber statt TWI-Implementierung benutzen */
+#define I2C_AVAILABLE /** < I2C-Treiber statt TWI-Implementierung benutzen */
 #endif
 
 #if defined CREATE_TRACEFILE_AVAILABLE && ! defined OS_AVAILABLE

--- a/include/bot-local.h
+++ b/include/bot-local.h
@@ -50,6 +50,7 @@
 #define BORDERSENSOR_POS_FW		DISTSENSOR_POS_FW  /**< Abgrundsensoren unter Distsensoren */
 #define BORDERSENSOR_POS_SW		(DISTSENSOR_POS_SW + 5) /**< Abgrundsensoren 5 mm weiter aussen als Distsensoren */
 
+
 /*** einstellbare Parameter ***/
 
 /* Parameter der Motorregelung */
@@ -85,8 +86,8 @@
 #define BPS_NO_DATA			0xffff /**< Wert des BPS-Sensors, falls keine Daten verfuegbar sind */
 
 /* System-Konstanten */
-#define F_CPU	16000000L	/**< CPU-Frequenz [Hz] */
-//#define F_CPU	20000000L	/**< CPU-Frequenz [Hz] */
+//#define F_CPU	16000000L	/**< CPU-Frequenz [Hz] */
+#define F_CPU	20000000L	/**< CPU-Frequenz [Hz] */
 #define XTAL	F_CPU		/**< CPU-Frequenz [Hz] */
 
 //#define UART_BAUD	57600	/**< Baudrate  57600 fuer UART-Kommunikation */
@@ -107,7 +108,7 @@
 #undef MOUSE_AVAILABLE					// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert MOUSE_AVAILABLE
 #endif // EXPANSION_BOARD_AVAILABLE
 
-//#define SPI_AVAILABLE		/**< verwendet den Hardware-SPI-Modus des Controllers, um mit der MMC zu kommunizieren. Muss ausserdem _immer_ an sein, wenn der Hardware-SPI-Umbau durchgefuehrt wurde! Hinweise in mcu/mmc.c beachten! */
+#define SPI_AVAILABLE		/**< verwendet den Hardware-SPI-Modus des Controllers, um mit der MMC zu kommunizieren. Muss ausserdem _immer_ an sein, wenn der Hardware-SPI-Umbau durchgefuehrt wurde! Hinweise in mcu/mmc.c beachten! */
 
 /* Servo-Parameter */
 #ifndef __AVR_ATmega1284P__

--- a/include/bot-local.h
+++ b/include/bot-local.h
@@ -31,139 +31,138 @@
 
 /*** Bot-Geometrie ***/
 
-#define BOT_DIAMETER			120			/**< Bot-Durchmesser [mm] */
-#define ENCODER_MARKS			60			/**< Anzahl der Flanken, die ein Encoder bei einer Radumdrehung liefert, also Anzahl der weissen + Anzahl der schwarzen Felder */
+#define BOT_DIAMETER			120						/** < Bot-Durchmesser [mm] */
+#define ENCODER_MARKS			60						/** < Anzahl der Flanken, die ein Encoder bei einer Radumdrehung liefert, also Anzahl der weissen + Anzahl der schwarzen Felder */
 #ifdef PC
-#define WHEEL_DIAMETER			56.7		/**< Durchmesser eines Rades (Sim) [mm] */
-#define WHEEL_PERIMETER			178.1283 	/**< Umfang eines Rades (Sim) [mm] */
-#define WHEEL_TO_WHEEL_DIAMETER 97.2 		/**< Abstand der beiden Raeder (Sim) [mm] */
+#define WHEEL_DIAMETER			56.7					/** < Durchmesser eines Rades (Sim) [mm] */
+#define WHEEL_PERIMETER			178.1283 				/** < Umfang eines Rades (Sim) [mm] */
+#define WHEEL_TO_WHEEL_DIAMETER 97.2 					/** < Abstand der beiden Raeder (Sim) [mm] */
 #else // MCU
 /* hier kann man die genauen Werte fuer den eigenen Bot eintragen */
-#define WHEEL_DIAMETER			56.7		/**< Durchmesser eines Rades [mm] */
-#define WHEEL_PERIMETER			178.1283 	/**< Umfang eines Rades [mm] */
-#define WHEEL_TO_WHEEL_DIAMETER 97.2 		/**< Abstand der beiden Raeder [mm] */
+#define WHEEL_DIAMETER			56.7					/** < Durchmesser eines Rades [mm] */
+#define WHEEL_PERIMETER			178.1283 				/** < Umfang eines Rades [mm] */
+#define WHEEL_TO_WHEEL_DIAMETER 97.2 					/** < Abstand der beiden Raeder [mm] */
 #endif // PC
 
-#define DISTSENSOR_POS_FW		47			/**< Abstand der Distanzsensoren von der Radachse (in Fahrtrichtung) [mm] */
-#define DISTSENSOR_POS_SW		32			/**< Abstand der Distanzsensoren von der Mittelachse (in Querrichtung) [mm] */
+#define DISTSENSOR_POS_FW		47						/** < Abstand der Distanzsensoren von der Radachse (in Fahrtrichtung) [mm] */
+#define DISTSENSOR_POS_SW		32						/** < Abstand der Distanzsensoren von der Mittelachse (in Querrichtung) [mm] */
 
-#define BORDERSENSOR_POS_FW		DISTSENSOR_POS_FW  /**< Abgrundsensoren unter Distsensoren */
-#define BORDERSENSOR_POS_SW		(DISTSENSOR_POS_SW + 5) /**< Abgrundsensoren 5 mm weiter aussen als Distsensoren */
+#define BORDERSENSOR_POS_FW		DISTSENSOR_POS_FW  		/** < Abgrundsensoren unter Distsensoren */
+#define BORDERSENSOR_POS_SW		(DISTSENSOR_POS_SW + 5) /** < Abgrundsensoren 5 mm weiter aussen als Distsensoren */
 
 
 /*** einstellbare Parameter ***/
 
 /* Parameter der Motorregelung */
-#define PID_Kp				70				/**< PID-Parameter proportional */
-#define PID_Ki				10				/**< PID-Parameter intergral */
-#define PID_Kd				20				/**< PID-Parameter differential */
-#define PID_Ta				1				/**< Abtastzeit */
-#define PID_SHIFT			4				/**< Rechtsshift der Stellgroessenkorrektur */
-#define PID_TIME			333				/**< max. Aufrufinterval [ms] */
-#define PID_SPEED_THRESHOLD	BOT_SPEED_FOLLOW/**< Grenzgeschwindigkeit, ab der die Regelgroesse interpoliert wird */
-#define PWMMAX				511				/**< Maximaler PWM-Wert */
-#define PWMMIN				0				/**< Minimaler PWM-Wert */
-#define PWMSTART_L			100				/**< Basis-PWM-Wert linker Motor (falls keine dauerhaft gespeicherte PWM-LT vorhanden ist) */
-#define PWMSTART_R			100				/**< Basis-PWM-Wert rechter Motor (falls keine dauerhaft gespeicherte PWM-LT vorhanden ist) */
-#define PID_START_DELAY		20				/**< Dauer der Anfahrverzoegerung */
-#define ENC_CORRECT_L		5				/**< Korrekturoffset fuer linken Radencoder (falls nicht kalibriert, sonst 0) */
-#define ENC_CORRECT_R		5				/**< Korrekturoffset fuer rechten Radencoder (falls nicht kalibriert, sonst 0) */
+#define PID_Kp				70					/** < PID-Parameter proportional */
+#define PID_Ki				10					/** < PID-Parameter intergral */
+#define PID_Kd				20					/** < PID-Parameter differential */
+#define PID_Ta				1					/** < Abtastzeit */
+#define PID_SHIFT			4					/** < Rechtsshift der Stellgroessenkorrektur */
+#define PID_TIME			333					/** < max. Aufrufinterval [ms] */
+#define PID_SPEED_THRESHOLD	BOT_SPEED_FOLLOW	/** < Grenzgeschwindigkeit, ab der die Regelgroesse interpoliert wird */
+#define PWMMAX				511					/** < Maximaler PWM-Wert */
+#define PWMMIN				0					/** < Minimaler PWM-Wert */
+#define PWMSTART_L			100					/** < Basis-PWM-Wert linker Motor (falls keine dauerhaft gespeicherte PWM-LT vorhanden ist) */
+#define PWMSTART_R			100					/** < Basis-PWM-Wert rechter Motor (falls keine dauerhaft gespeicherte PWM-LT vorhanden ist) */
+#define PID_START_DELAY		20					/** < Dauer der Anfahrverzoegerung */
+#define ENC_CORRECT_L		5					/** < Korrekturoffset fuer linken Radencoder (falls nicht kalibriert, sonst 0) */
+#define ENC_CORRECT_R		5					/** < Korrekturoffset fuer rechten Radencoder (falls nicht kalibriert, sonst 0) */
 
 /* Odometrie-Konstanten */
 #ifdef PC
-#define MOUSE_CPI		400		/**< CPI-Wert aus Kalibrierung (Wert fuer den Sim) */
-#define MOUSE_FULL_TURN	1484	/**< Mausaenderung in X-Richtung fuer einen vollen Kreis (Wert fuer den Sim) */
+#define MOUSE_CPI		400									/** < CPI-Wert aus Kalibrierung (Wert fuer den Sim) */
+#define MOUSE_FULL_TURN	1484								/** < Mausaenderung in X-Richtung fuer einen vollen Kreis (Wert fuer den Sim) */
 #else // MCU
-#define MOUSE_CPI		415		/**< CPI-Wert aus Kalibrierung */
-#define MOUSE_FULL_TURN	1600	/**< Mausaenderung in X-Richtung fuer einen vollen Kreis */
+#define MOUSE_CPI		415									/** < CPI-Wert aus Kalibrierung */
+#define MOUSE_FULL_TURN	1600								/** < Mausaenderung in X-Richtung fuer einen vollen Kreis */
 #endif // PC
 
-#define WHEEL_DISTANCE		(WHEEL_TO_WHEEL_DIAMETER / 2.0f)	/**< Abstand eines Rades zur Mitte des Bots [mm] */
-#define STUCK_DIFF			100		/**< ab welcher Differenz haben wir durchdrehende Raeder? */
-#define G_SPEED				0.5		/**< Kopplung Encoder- und Maussensor fuer Geschwindigkeiten (0.0=nur Radencoder, 1.0=nur Maussensor) */
-#define G_POS				0.5		/**< Kopplung Encoder- und Maussensor fuer Positionen und Winkel (0.0=nur Radencoder, 1.0=nur Maussensor) */
+#define WHEEL_DISTANCE	(WHEEL_TO_WHEEL_DIAMETER / 2.0f)	/** < Abstand eines Rades zur Mitte des Bots [mm] */
+#define STUCK_DIFF		100									/** < ab welcher Differenz haben wir durchdrehende Raeder? */
+#define G_SPEED			0.5									/** < Kopplung Encoder- und Maussensor fuer Geschwindigkeiten (0.0=nur Radencoder, 1.0=nur Maussensor) */
+#define G_POS			0.5									/** < Kopplung Encoder- und Maussensor fuer Positionen und Winkel (0.0=nur Radencoder, 1.0=nur Maussensor) */
 
-#define BPS_NO_DATA			0xffff /**< Wert des BPS-Sensors, falls keine Daten verfuegbar sind */
+#define BPS_NO_DATA			0xffff 							/** < Wert des BPS-Sensors, falls keine Daten verfuegbar sind */
 
 /* System-Konstanten */
-//#define F_CPU	16000000L	/**< CPU-Frequenz [Hz] */
-#define F_CPU	20000000L	/**< CPU-Frequenz [Hz] */
-#define XTAL	F_CPU		/**< CPU-Frequenz [Hz] */
+#define F_CPU	16000000L									/** < CPU-Frequenz [Hz] */
+//#define F_CPU	20000000L									/** < CPU-Frequenz [Hz] */
+#define XTAL	F_CPU										/** < CPU-Frequenz [Hz] */
 
-//#define UART_BAUD	57600	/**< Baudrate  57600 fuer UART-Kommunikation */
-#define UART_BAUD	115200	/**< Baudrate 115200 fuer UART-Kommunikation */
-//#define UART_BAUD	230400	/**< Baudrate 230400 fuer UART-Kommunikation */
-//#define UART_BAUD	500000	/**< Baudrate 500000 fuer UART-Kommunikation */
+//#define UART_BAUD	57600									/** < Baudrate  57600 fuer UART-Kommunikation */
+#define UART_BAUD	115200									/** < Baudrate 115200 fuer UART-Kommunikation */
+//#define UART_BAUD	230400									/** < Baudrate 230400 fuer UART-Kommunikation */
+//#define UART_BAUD	500000									/** < Baudrate 500000 fuer UART-Kommunikation */
 
-#define UART_LINUX_PORT		"/dev/ttyAMA0" /**< UART Port vom ARM-Linux-Board fuer Verbinung zum ATmega */
-#define BOT_RESET_GPIO		"/sys/class/gpio/gpio17/value" /**< Pfad zum Reset-GPIO vom ARM-Linux-Board */
-//#define ARM_LINUX_DISPLAY	"/dev/tty1" /**< Konsole fuer Display-Ausgaben auf ARM-Linux-Board. "stdout" fuer Ausgabe auf stdout */
+#define UART_LINUX_PORT		"/dev/ttyAMA0" 					/** < UART Port vom ARM-Linux-Board fuer Verbinung zum ATmega */
+#define BOT_RESET_GPIO		"/sys/class/gpio/gpio17/value" 	/** < Pfad zum Reset-GPIO vom ARM-Linux-Board */
+//#define ARM_LINUX_DISPLAY	"/dev/tty1" 					/** < Konsole fuer Display-Ausgaben auf ARM-Linux-Board. "stdout" fuer Ausgabe auf stdout */
 
-#define EXPANSION_BOARD_AVAILABLE 		/**< Erweiterungsmodul (MMC / WiPort) installiert */
-
-//#define EXPANSION_BOARD_MOD_AVAILABLE	/**< modifiziertes Erweiterungsmodul (MMC / WiPort) installiert */
+#define EXPANSION_BOARD_AVAILABLE 							/** < Erweiterungsmodul (MMC / WiPort) installiert */
+//#define EXPANSION_BOARD_MOD_AVAILABLE						/** < modifiziertes Erweiterungsmodul (MMC / WiPort) installiert */
 
 #if defined EXPANSION_BOARD_MOD_AVAILABLE
-#undef EXPANSION_BOARD_AVAILABLE		// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert EXPANSION_BOARD_AVAILABLE
-#undef MOUSE_AVAILABLE					// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert MOUSE_AVAILABLE
+#undef EXPANSION_BOARD_AVAILABLE	// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert EXPANSION_BOARD_AVAILABLE
+#undef MOUSE_AVAILABLE				// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert MOUSE_AVAILABLE
 #endif // EXPANSION_BOARD_AVAILABLE
 
-#define SPI_AVAILABLE		/**< verwendet den Hardware-SPI-Modus des Controllers, um mit der MMC zu kommunizieren. Muss ausserdem _immer_ an sein, wenn der Hardware-SPI-Umbau durchgefuehrt wurde! Hinweise in mcu/mmc.c beachten! */
+//#define SPI_AVAILABLE										/** < verwendet den Hardware-SPI-Modus des Controllers, um mit der MMC zu kommunizieren. Muss ausserdem _immer_ an sein, wenn der Hardware-SPI-Umbau durchgefuehrt wurde! Hinweise in mcu/mmc.c beachten! */
 
 /* Servo-Parameter */
 #ifndef __AVR_ATmega1284P__
 #if F_CPU == 16000000L
-#define DOOR_CLOSE 	7  /**< Rechter Anschlag Servo 1 */
-#define DOOR_OPEN	14 /**< Linker Anschlag Servo 1 */
-#define CAM_LEFT 	7  /**< Rechter Anschlag Servo 2 */
-#define CAM_RIGHT	14 /**< Linker Anschlag Servo 2 */
+#define DOOR_CLOSE 	7  	/** < Rechter Anschlag Servo 1 */
+#define DOOR_OPEN	14 	/** < Linker Anschlag Servo 1 */
+#define CAM_LEFT 	7  	/** < Rechter Anschlag Servo 2 */
+#define CAM_RIGHT	14 	/** < Linker Anschlag Servo 2 */
 #else
-#define DOOR_CLOSE 	10 /**< Rechter Anschlag Servo 1 */
-#define DOOR_OPEN	18 /**< Linker Anschlag Servo 1 */
-#define CAM_LEFT 	10 /**< Rechter Anschlag Servo 2 */
-#define CAM_RIGHT	18 /**< Linker Anschlag Servo 2 */
+#define DOOR_CLOSE 	10 	/** < Rechter Anschlag Servo 1 */
+#define DOOR_OPEN	18 	/** < Linker Anschlag Servo 1 */
+#define CAM_LEFT 	10 	/** < Rechter Anschlag Servo 2 */
+#define CAM_RIGHT	18 	/** < Linker Anschlag Servo 2 */
 #endif // F_CPU
 #else
-#define DOOR_CLOSE 	64  /**< Rechter Anschlag Servo 1 */
-#define DOOR_OPEN	180 /**< Linker Anschlag Servo 1 */
-#define CAM_LEFT 	64  /**< Rechter Anschlag Servo 2 */
-#define CAM_RIGHT	180 /**< Linker Anschlag Servo 2 */
+#define DOOR_CLOSE 	64  /** < Rechter Anschlag Servo 1 */
+#define DOOR_OPEN	180 /** < Linker Anschlag Servo 1 */
+#define CAM_LEFT 	64  /** < Rechter Anschlag Servo 2 */
+#define CAM_RIGHT	180 /** < Linker Anschlag Servo 2 */
 #endif // ! __AVR_ATmega1284P__
 
 
 /*** Einstellungen fuer die Verhaltensregeln ***/
 
 /* bot_avoid_border_behaviour() */
-#define BORDER_DANGEROUS	0x3A0	/**< Wert, ab dem wir sicher sind, dass es eine Kante ist */
+#define BORDER_DANGEROUS	0x3A0	/** < Wert, ab dem wir sicher sind, dass es eine Kante ist */
 
 /* bot_avoid_col_behaviour() */
-#define COL_CLOSEST			200		/**< Abstand [mm], den wir als zu nah betrachten -- je nach echtem Sensor ist das schon zu nah! */
-#define COL_NEAR			300		/**< Nahbereich [mm] */
-#define COL_FAR				400		/**< Fernbereich [mm] */
+#define COL_CLOSEST			200		/** < Abstand [mm], den wir als zu nah betrachten -- je nach echtem Sensor ist das schon zu nah! */
+#define COL_NEAR			300		/** < Nahbereich [mm] */
+#define COL_FAR				400		/** < Fernbereich [mm] */
 
 /* Zustaende und Konstanten fuer das bot_solve_maze_behaviour-Verhalten */
-#define OPTIMAL_DISTANCE	(int16_t)(BOT_DIAMETER * 1.25f)	/**< Optimale Distanz zur Wand [mm]. Etwas mehr als Bot-Durchmesser ist ideal (vergroessert aufgrund der Kennlinien der Sharps) */
-#define ADJUST_DISTANCE		10		/**< Toleranzbereich [mm] */
-#define IGNORE_DISTANCE		240		/**< Entfernung, ab der eine Wand ignoriert wird [mm] */
-#define GROUND_GOAL			0x221	/**< Farbe des Zielpads */
-#define STARTPAD1			0x2B2	/**< Farbe des Startpads1 */
-#define STARTPAD2			0x332	/**< Farbe des Startpads2 */
+#define OPTIMAL_DISTANCE	(int16_t)(BOT_DIAMETER * 1.25f)	/** < Optimale Distanz zur Wand [mm]. Etwas mehr als Bot-Durchmesser ist ideal (vergroessert aufgrund der Kennlinien der Sharps) */
+#define ADJUST_DISTANCE		10		/** < Toleranzbereich [mm] */
+#define IGNORE_DISTANCE		240		/** < Entfernung, ab der eine Wand ignoriert wird [mm] */
+#define GROUND_GOAL			0x221	/** < Farbe des Zielpads */
+#define STARTPAD1			0x2B2	/** < Farbe des Startpads1 */
+#define STARTPAD2			0x332	/** < Farbe des Startpads2 */
 
 /* bot_follow_line_behaviour() */
 #ifdef PC
 /** Konstante fuer das bot_follow_line_behaviour-Verhalten im Sim */
-#define LINE_SENSE		0x350	/**< Linie im Sim = 0x350 */
+#define LINE_SENSE		0x350		/** < Linie im Sim = 0x350 */
 #else
 /** Konstante fuer das bot_follow_line_behaviour-Verhalten auf dem echten Bot*/
-#define LINE_SENSE		0x200	/**< Ab wann ist es eine Linie? (schwarz ca. 0x300, helle Tischflaeche 0x50) */
+#define LINE_SENSE		0x200		/** < Ab wann ist es eine Linie? (schwarz ca. 0x300, helle Tischflaeche 0x50) */
 #endif // PC
 
 /* Konstanten fuer bot_catch_pillar_behaviour() */
-#define MAX_PILLAR_DISTANCE	500 /**< max. Entfernung zum Objekt [mm] */
+#define MAX_PILLAR_DISTANCE	500 	/** < max. Entfernung zum Objekt [mm] */
 
 /* Konstanten fuer Verhaltensanzeige, Verhalten mit prio von bis sichtbar */
-#define PRIO_VISIBLE_MIN	3	/**< Prioritaet, die ein Verhalten mindestens haben muss, um angezeigt zu werden */
-#define PRIO_VISIBLE_MAX	200	/**< Prioritaet, die ein Verhalten hoechstens haben darf, um angezeigt zu werden */
+#define PRIO_VISIBLE_MIN	3		/** < Prioritaet, die ein Verhalten mindestens haben muss, um angezeigt zu werden */
+#define PRIO_VISIBLE_MAX	200		/** < Prioritaet, die ein Verhalten hoechstens haben darf, um angezeigt zu werden */
 
 
 #include <bot-local-override.h>

--- a/include/bot-logic/available_behaviours.h
+++ b/include/bot-logic/available_behaviours.h
@@ -79,7 +79,7 @@
 #define BEHAVIOUR_DELAY_AVAILABLE /**< Delay-Routinen als Verhalten */
 #define BEHAVIOUR_CANCEL_BEHAVIOUR_AVAILABLE /**< Deaktivieren von Verhalten wenn eine Abbruchbedingung erfuellt ist */
 //#define BEHAVIOUR_GET_UTILIZATION_AVAILABLE	/**< CPU-Auslastung eines Verhaltens messen */
-//#define BEHAVIOUR_HW_TEST_AVAILABLE /**< Testverhalten vorhanden? (ehemals TEST_AVAILABLE_ANALOG, _DIGITAL, _MOTOR) */
+#define BEHAVIOUR_HW_TEST_AVAILABLE /**< Testverhalten vorhanden? (ehemals TEST_AVAILABLE_ANALOG, _DIGITAL, _MOTOR) */
 
 /** sonstige Verhalten */
 //#define BEHAVIOUR_NEURALNET_AVAILABLE /**< neuronales Netzwerk vorhanden? */

--- a/include/bot-logic/available_behaviours.h
+++ b/include/bot-logic/available_behaviours.h
@@ -40,7 +40,7 @@
 
 /** Positionierungs-Verhalten */
 //#define BEHAVIOUR_GOTO_AVAILABLE 					/** < goto vorhanden? */
-//#define BEHAVIOUR_DRIVE_DISTANCE_AVAILABLE 		/** < Strecke fahren vorhanden ?*/
+//#define BEHAVIOUR_DRIVE_DISTANCE_AVAILABLE 		/** < Strecke fahren vorhanden? */
 //#define BEHAVIOUR_GOTOXY_AVAILABLE 				/** < gotoxy vorhanden? */
 #define BEHAVIOUR_TURN_AVAILABLE 					/** < turn vorhanden? */
 //#define BEHAVIOUR_TURN_TEST_AVAILABLE 			/** < turn_test vorhanden? */

--- a/include/bot-logic/available_behaviours.h
+++ b/include/bot-logic/available_behaviours.h
@@ -27,63 +27,63 @@
 
 #ifdef BEHAVIOUR_AVAILABLE
 
-//#define BEHAVIOUR_PROTOTYPE_AVAILABLE /**< Prototyp fuer neue Verhalten */
+//#define BEHAVIOUR_PROTOTYPE_AVAILABLE 			/** < Prototyp fuer neue Verhalten */
 
 /** Demo-Verhalten */
-//#define BEHAVIOUR_SIMPLE_AVAILABLE /**< sind die Beispielverhalten vorhanden? */
-//#define BEHAVIOUR_DRIVE_SQUARE_AVAILABLE /**< Demoverhalten im Quadrat fahren vorhanden? */
+//#define BEHAVIOUR_SIMPLE_AVAILABLE				/** < sind die Beispielverhalten vorhanden? */
+//#define BEHAVIOUR_DRIVE_SQUARE_AVAILABLE 			/** < Demoverhalten im Quadrat fahren vorhanden? */
 
 /** Notfall-Verhalten */
-//#define BEHAVIOUR_AVOID_BORDER_AVAILABLE /**< Abgruenden ausweichen vorhanden? */
-//#define BEHAVIOUR_AVOID_COL_AVAILABLE /**< Hindernis ausweichen vorhanden? */
-//#define BEHAVIOUR_HANG_ON_AVAILABLE /**< Erkennen des Haengenbleibens als Notfallverhalten? */
+//#define BEHAVIOUR_AVOID_BORDER_AVAILABLE 			/** < Abgruenden ausweichen vorhanden? */
+//#define BEHAVIOUR_AVOID_COL_AVAILABLE 			/** < Hindernis ausweichen vorhanden? */
+//#define BEHAVIOUR_HANG_ON_AVAILABLE 				/** < Erkennen des Haengenbleibens als Notfallverhalten? */
 
 /** Positionierungs-Verhalten */
-//#define BEHAVIOUR_GOTO_AVAILABLE /**< goto vorhanden? */
-//#define BEHAVIOUR_DRIVE_DISTANCE_AVAILABLE /**< Strecke fahren vorhanden ?*/
-//#define BEHAVIOUR_GOTOXY_AVAILABLE /**< gotoxy vorhanden? */
-#define BEHAVIOUR_TURN_AVAILABLE /**< turn vorhanden? */
-//#define BEHAVIOUR_TURN_TEST_AVAILABLE /**< turn_test vorhanden? */
-#define BEHAVIOUR_GOTO_POS_AVAILABLE /**< goto_pos vorhanden? */
-//#define BEHAVIOUR_GOTO_OBSTACLE_AVAILABLE /**< goto_obstacle vorhanden? */
-//#define BEHAVIOUR_DRIVE_STACK_AVAILABLE /**< Abfahren der auf dem Stack gesicherten Koordinaten */
-//#define BEHAVIOUR_TEST_ENCODER_AVAILABLE /**< Encoder-Test Verhalten vorhanden? */
+//#define BEHAVIOUR_GOTO_AVAILABLE 					/** < goto vorhanden? */
+//#define BEHAVIOUR_DRIVE_DISTANCE_AVAILABLE 		/** < Strecke fahren vorhanden ?*/
+//#define BEHAVIOUR_GOTOXY_AVAILABLE 				/** < gotoxy vorhanden? */
+#define BEHAVIOUR_TURN_AVAILABLE 					/** < turn vorhanden? */
+//#define BEHAVIOUR_TURN_TEST_AVAILABLE 			/** < turn_test vorhanden? */
+#define BEHAVIOUR_GOTO_POS_AVAILABLE 				/** < goto_pos vorhanden? */
+//#define BEHAVIOUR_GOTO_OBSTACLE_AVAILABLE 		/** < goto_obstacle vorhanden? */
+//#define BEHAVIOUR_DRIVE_STACK_AVAILABLE 			/** < Abfahren der auf dem Stack gesicherten Koordinaten */
+//#define BEHAVIOUR_TEST_ENCODER_AVAILABLE 			/** < Encoder-Test Verhalten vorhanden? */
 
 /** Anwendungs-Verhalten */
-#define BEHAVIOUR_SOLVE_MAZE_AVAILABLE /**< Wandfolger vorhanden? */
-//#define BEHAVIOUR_FOLLOW_LINE_AVAILABLE	/**< Linienfolger vorhanden? */
-//#define BEHAVIOUR_FOLLOW_LINE_ENHANCED_AVAILABLE /**< erweiterter Linienfolger, der auch mit Unterbrechungen und Hindernissen klarkommt */
-//#define BEHAVIOUR_PATHPLANING_AVAILABLE /**< Pfadplanungsverhalten  */
-//#define BEHAVIOUR_OLYMPIC_AVAILABLE	/**< Olympiadenverhalten vorhanden? */
-//#define BEHAVIOUR_CATCH_PILLAR_AVAILABLE /**< Suche eine Dose und fange sie ein */
-//#define BEHAVIOUR_CLASSIFY_OBJECTS_AVAILABLE /**< Trennt zwei Arten von Dosen (hell / dunkel) */
-//#define BEHAVIOUR_TRANSPORT_PILLAR_AVAILABLE /**< Transport-Pillar Verhalten */
-//#define BEHAVIOUR_FOLLOW_OBJECT_AVAILABLE /**< verfolge ein (bewegliches) Objekt */
-//#define BEHAVIOUR_FOLLOW_WALL_AVAILABLE /**< Follow Wall Explorer Verhalten */
-//#define BEHAVIOUR_DRIVE_AREA_AVAILABLE /**< flaechendeckendes Fahren mit Map */
-//#define BEHAVIOUR_LINE_SHORTEST_WAY_AVAILABLE /**< Linienfolger ueber Kreuzungen zum Ziel */
-//#define BEHAVIOUR_DRIVE_CHESS_AVAILABLE /**< Schach fuer den Bot */
-//#define BEHAVIOUR_SCAN_BEACONS_AVAILABLE /**< Suchen von Landmarken zur Lokalisierung */
-//#define BEHAVIOUR_UBASIC_AVAILABLE /**< uBasic Verhalten */
-//#define BEHAVIOUR_ABL_AVAILABLE /**< ABL-Interpreter */
+#define BEHAVIOUR_SOLVE_MAZE_AVAILABLE 				/** < Wandfolger vorhanden? */
+//#define BEHAVIOUR_FOLLOW_LINE_AVAILABLE			/** < Linienfolger vorhanden? */
+//#define BEHAVIOUR_FOLLOW_LINE_ENHANCED_AVAILABLE 	/** < erweiterter Linienfolger, der auch mit Unterbrechungen und Hindernissen klarkommt */
+//#define BEHAVIOUR_PATHPLANING_AVAILABLE 			/** < Pfadplanungsverhalten  */
+//#define BEHAVIOUR_OLYMPIC_AVAILABLE				/** < Olympiadenverhalten vorhanden? */
+//#define BEHAVIOUR_CATCH_PILLAR_AVAILABLE 			/** < Suche eine Dose und fange sie ein */
+//#define BEHAVIOUR_CLASSIFY_OBJECTS_AVAILABLE 		/** < Trennt zwei Arten von Dosen (hell / dunkel) */
+//#define BEHAVIOUR_TRANSPORT_PILLAR_AVAILABLE 		/** < Transport-Pillar Verhalten */
+//#define BEHAVIOUR_FOLLOW_OBJECT_AVAILABLE 		/** < verfolge ein (bewegliches) Objekt */
+//#define BEHAVIOUR_FOLLOW_WALL_AVAILABLE 			/** < Follow Wall Explorer Verhalten */
+//#define BEHAVIOUR_DRIVE_AREA_AVAILABLE 			/** < flaechendeckendes Fahren mit Map */
+//#define BEHAVIOUR_LINE_SHORTEST_WAY_AVAILABLE 	/** < Linienfolger ueber Kreuzungen zum Ziel */
+//#define BEHAVIOUR_DRIVE_CHESS_AVAILABLE 			/** < Schach fuer den Bot */
+//#define BEHAVIOUR_SCAN_BEACONS_AVAILABLE 			/** < Suchen von Landmarken zur Lokalisierung */
+//#define BEHAVIOUR_UBASIC_AVAILABLE 				/** < uBasic Verhalten */
+//#define BEHAVIOUR_ABL_AVAILABLE 					/** < ABL-Interpreter */
 
 /** Kalibrierungs-Verhalten */
-//#define BEHAVIOUR_CALIBRATE_PID_AVAILABLE /**< Kalibrierungsverhalten fuer Motorregelung vorhanden? */
-//#define BEHAVIOUR_CALIBRATE_SHARPS_AVAILABLE /**< Kalibrierungsverhalten fuer Distanzsensoren vorhanden? */
+//#define BEHAVIOUR_CALIBRATE_PID_AVAILABLE			/** < Kalibrierungsverhalten fuer Motorregelung vorhanden? */
+//#define BEHAVIOUR_CALIBRATE_SHARPS_AVAILABLE 		/** < Kalibrierungsverhalten fuer Distanzsensoren vorhanden? */
 
 /** System-Verhalten */
-#define BEHAVIOUR_SCAN_AVAILABLE /**< Gegend scannen vorhanden? */
-#define BEHAVIOUR_SERVO_AVAILABLE 	/**< Kontrollverhalten fuer die Servos */
-#define BEHAVIOUR_REMOTECALL_AVAILABLE /**< Nehmen wir Remote-Kommandos entgegen? */
-#define BEHAVIOUR_MEASURE_DISTANCE_AVAILABLE /**< Distanzesensorasuwertung vorhanden? */
-#define BEHAVIOUR_DELAY_AVAILABLE /**< Delay-Routinen als Verhalten */
-#define BEHAVIOUR_CANCEL_BEHAVIOUR_AVAILABLE /**< Deaktivieren von Verhalten wenn eine Abbruchbedingung erfuellt ist */
-//#define BEHAVIOUR_GET_UTILIZATION_AVAILABLE	/**< CPU-Auslastung eines Verhaltens messen */
-#define BEHAVIOUR_HW_TEST_AVAILABLE /**< Testverhalten vorhanden? (ehemals TEST_AVAILABLE_ANALOG, _DIGITAL, _MOTOR) */
+#define BEHAVIOUR_SCAN_AVAILABLE 					/** < Gegend scannen vorhanden? */
+#define BEHAVIOUR_SERVO_AVAILABLE 					/** < Kontrollverhalten fuer die Servos */
+#define BEHAVIOUR_REMOTECALL_AVAILABLE 				/** < Nehmen wir Remote-Kommandos entgegen? */
+#define BEHAVIOUR_MEASURE_DISTANCE_AVAILABLE 		/** < Distanzesensorasuwertung vorhanden? */
+#define BEHAVIOUR_DELAY_AVAILABLE 					/** < Delay-Routinen als Verhalten */
+#define BEHAVIOUR_CANCEL_BEHAVIOUR_AVAILABLE 		/** < Deaktivieren von Verhalten wenn eine Abbruchbedingung erfuellt ist */
+//#define BEHAVIOUR_GET_UTILIZATION_AVAILABLE		/** < CPU-Auslastung eines Verhaltens messen */
+//#define BEHAVIOUR_HW_TEST_AVAILABLE 				/** < Testverhalten vorhanden? (ehemals TEST_AVAILABLE_ANALOG, _DIGITAL, _MOTOR) */
 
 /** sonstige Verhalten */
-//#define BEHAVIOUR_NEURALNET_AVAILABLE /**< neuronales Netzwerk vorhanden? */
-//#define BEHAVIOUR_DRIVE_NEURALNET_AVAILABLE /**< Fahrverhalten fuer das neuronale Netzwerk vorhanden? */
+//#define BEHAVIOUR_NEURALNET_AVAILABLE 			/** < neuronales Netzwerk vorhanden? */
+//#define BEHAVIOUR_DRIVE_NEURALNET_AVAILABLE 		/** < Fahrverhalten fuer das neuronale Netzwerk vorhanden? */
 
 
 /* Aufgrund einer ganzen Reihe von Abhaengigkeiten sollte man beim Versuch Speicher

--- a/mcu/sensor-low.c
+++ b/mcu/sensor-low.c
@@ -51,63 +51,63 @@
 #include "init.h"
 
 // ADC-PINS
-#define SENS_ABST_L		0		/**< ADC-PIN Abstandssensor Links */
-#define SENS_ABST_R		1		/**< ADC-PIN Abstandssensor Rechts */
-#define SENS_M_L		2		/**< ADC-PIN Liniensensor Links */
-#define SENS_M_R		3		/**< ADC-PIN Liniensensor Rechts */
-#define SENS_LDR_L		4		/**< ADC-PIN Lichtsensor Links */
-#define SENS_LDR_R		5		/**< ADC-PIN Lichtsensor Rechts */
-#define SENS_KANTE_L	6		/**< ADC-PIN Kantensensor Links */
-#define SENS_KANTE_R	7		/**< ADC-PIN Kantensensor Rechts */
+#define SENS_ABST_L			0		/** < ADC-PIN Abstandssensor Links */
+#define SENS_ABST_R			1		/** < ADC-PIN Abstandssensor Rechts */
+#define SENS_M_L			2		/** < ADC-PIN Liniensensor Links */
+#define SENS_M_R			3		/** < ADC-PIN Liniensensor Rechts */
+#define SENS_LDR_L			4		/** < ADC-PIN Lichtsensor Links */
+#define SENS_LDR_R			5		/** < ADC-PIN Lichtsensor Rechts */
+#define SENS_KANTE_L		6		/** < ADC-PIN Kantensensor Links */
+#define SENS_KANTE_R		7		/** < ADC-PIN Kantensensor Rechts */
 
 // Sonstige Sensoren
-#define SENS_DOOR_PINR 		PIND	/**< Port an dem der Klappensensor haengt */
-#define SENS_DOOR_DDR 		DDRD	/**< DDR fuer den Klappensensor */
-#define SENS_DOOR			6		/**< Pin an dem der Klappensensor haengt */
+#define SENS_DOOR_PINR 		PIND	/** < Port an dem der Klappensensor haengt */
+#define SENS_DOOR_DDR 		DDRD	/** < DDR fuer den Klappensensor */
+#define SENS_DOOR			6		/** < Pin an dem der Klappensensor haengt */
 
 #ifdef SPI_AVAILABLE
-#define SENS_ENCL_PINR		PINC	/**< Port an dem der linke Encoder haengt */
-#define SENS_ENCL_DDR		DDRC	/**< DDR fuer den linken Encoder  */
-#define SENS_ENCL			5		/**< Pin an dem der linke Encoder haengt */
+#define SENS_ENCL_PINR		PINC	/** < Port an dem der linke Encoder haengt */
+#define SENS_ENCL_DDR		DDRC	/** < DDR fuer den linken Encoder  */
+#define SENS_ENCL			5		/** < Pin an dem der linke Encoder haengt */
 #else
-#define SENS_ENCL_PINR		PINB	/**< Port an dem der linke Encoder haengt */
-#define SENS_ENCL_DDR		DDRB	/**< DDR fuer den linken Encoder  */
-#define SENS_ENCL			4		/**< Pin an dem der linke Encoder haengt */
+#define SENS_ENCL_PINR		PINB	/** < Port an dem der linke Encoder haengt */
+#define SENS_ENCL_DDR		DDRB	/** < DDR fuer den linken Encoder  */
+#define SENS_ENCL			4		/** < Pin an dem der linke Encoder haengt */
 #endif	// SPI_AVAILABLE
 
-#define SENS_ENCR_PINR		PIND	/**< Port an dem der rechte Encoder haengt */
-#define SENS_ENCR_DDR		DDRD	/**< DDR fuer den rechten Encoder  */
-#define SENS_ENCR			3		/**< Pin an dem der rechte Encoder haengt */
+#define SENS_ENCR_PINR		PIND	/** < Port an dem der rechte Encoder haengt */
+#define SENS_ENCR_DDR		DDRD	/** < DDR fuer den rechten Encoder  */
+#define SENS_ENCR			3		/** < Pin an dem der rechte Encoder haengt */
 
-#define SENS_ERROR_PINR		PINB	/**< Port an dem die Fehlerueberwachung haengt */
-#define SENS_ERROR_DDR		DDRB	/**< DDR fuer die Fehlerueberwachung */
-#define SENS_ERROR			2		/**< Pin an dem die Fehlerueberwachung haengt */
+#define SENS_ERROR_PINR		PINB	/** < Port an dem die Fehlerueberwachung haengt */
+#define SENS_ERROR_DDR		DDRB	/** < DDR fuer die Fehlerueberwachung */
+#define SENS_ERROR			2		/** < Pin an dem die Fehlerueberwachung haengt */
 
-#define SENS_TRANS_PINR		PINB	/**< Port an dem die Transportfachueberwachung haengt */
-#define SENS_TRANS_PORT		PORTB	/**< Port an dem die Transportfachueberwachung haengt */
-#define SENS_TRANS_DDR		DDRB	/**< DDR fuer die Transportfachueberwachung */
-#define SENS_TRANS			0		/**< Pin an dem die Transportfachueberwachung haengt */
+#define SENS_TRANS_PINR		PINB	/** < Port an dem die Transportfachueberwachung haengt */
+#define SENS_TRANS_PORT		PORTB	/** < Port an dem die Transportfachueberwachung haengt */
+#define SENS_TRANS_DDR		DDRB	/** < DDR fuer die Transportfachueberwachung */
+#define SENS_TRANS			0		/** < Pin an dem die Transportfachueberwachung haengt */
 
-#define ENC_L ((SENS_ENCL_PINR >> SENS_ENCL) & 0x01)	/**< Abkuerzung zum Zugriff auf Encoder */
-#define ENC_R ((SENS_ENCR_PINR >> SENS_ENCR) & 0x01)	/**< Abkuerzung zum Zugriff auf Encoder */
+#define ENC_L ((SENS_ENCL_PINR >> SENS_ENCL) & 0x01)	/** < Abkuerzung zum Zugriff auf Encoder */
+#define ENC_R ((SENS_ENCR_PINR >> SENS_ENCR) & 0x01)	/** < Abkuerzung zum Zugriff auf Encoder */
 
-#define ENC_ENTPRELL	12		/**< Nur wenn der Encoder ein paar mal den gleichen wert gibt uebernehmen */
+#define ENC_ENTPRELL		12		/** < Nur wenn der Encoder ein paar mal den gleichen wert gibt uebernehmen */
 
 #ifdef SPEED_CONTROL_AVAILABLE
-uint16_t encTimeL[8] = {0};	/**< Timestamps linker Encoder */
-uint16_t encTimeR[8] = {0};	/**< Timestamps rechter Encoder */
-uint8_t i_encTimeL = 0;		/**< Array-Index auf letzten Timestampeintrag links */
-uint8_t i_encTimeR = 0;		/**< Array-Index auf letzten Timestampeintrag rechts */
-uint8_t timeCorrectL = 0;	/**< markiert, ob der Encoder-Timestamp des linken Rads ungueltig ist (wg. Stillstand) */
-uint8_t timeCorrectR = 0;	/**< markiert, ob der Encoder-Timestamp des rechten Rads ungueltig ist (wg. Stillstand) */
+uint16_t encTimeL[8] = {0};	/** < Timestamps linker Encoder */
+uint16_t encTimeR[8] = {0};	/** < Timestamps rechter Encoder */
+uint8_t i_encTimeL = 0;		/** < Array-Index auf letzten Timestampeintrag links */
+uint8_t i_encTimeR = 0;		/** < Array-Index auf letzten Timestampeintrag rechts */
+uint8_t timeCorrectL = 0;	/** < markiert, ob der Encoder-Timestamp des linken Rads ungueltig ist (wg. Stillstand) */
+uint8_t timeCorrectR = 0;	/** < markiert, ob der Encoder-Timestamp des rechten Rads ungueltig ist (wg. Stillstand) */
 #endif // SPEED_CONTROL_AVAILABLE
 
 #ifdef SPEED_LOG_AVAILABLE
 /* Debug-Loggings */
-volatile uint8_t slog_i[2] = {0,0}; /**< Array-Index */
-slog_t * const slog = &GET_MMC_BUFFER(speedlog); /**< Puffer fuer Speed-Log Daten */
-static botfs_file_descr_t speedlog_file; /**< BotFS-Datei fuer das Speed-Log */
-#define SPEEDLOG_FILE_SIZE (1024 * (1024 / BOTFS_BLOCK_SIZE)) /**< Groesse der Speed-Log-Datei in Bloecken */
+volatile uint8_t slog_i[2] = {0,0}; /** < Array-Index */
+slog_t * const slog = &GET_MMC_BUFFER(speedlog); /** < Puffer fuer Speed-Log Daten */
+static botfs_file_descr_t speedlog_file; /** < BotFS-Datei fuer das Speed-Log */
+#define SPEEDLOG_FILE_SIZE (1024 * (1024 / BOTFS_BLOCK_SIZE)) /** < Groesse der Speed-Log-Datei in Bloecken */
 #endif // SPEED_LOG_AVAILABLE
 
 #define FILTER_SIZE (sizeof(dist_fir_coeffs) / sizeof(dist_fir_coeffs[0]))

--- a/ui/rc5.c
+++ b/ui/rc5.c
@@ -305,11 +305,12 @@ void default_key_handler(void) {
 		case RC5_CH_MINUS:		bot_servo(NULL, SERVO1, DOOR_OPEN); break;
 #endif
 #ifdef RC5_VOL_PLUS
-		case RC5_VOL_PLUS:		rc5_change_servo2(1); break; // verfährt Servo 2 um eine Stufe im Uhrzeigersinn
+		case RC5_VOL_PLUS:		/* bot_servo(NULL, SERVO2, CAM_RIGHT); break; */ rc5_change_servo2(1); break; // verfaehrt Servo 2 um eine Stufe im Uhrzeigersinn
 #endif
 #ifdef RC5_VOL_MINUS
-		case RC5_VOL_MINUS:		rc5_change_servo2(-1); break; // verfährt Servo 2 um eine Stufe gegen den Uhrzeigersinn
+		case RC5_VOL_MINUS:		/* bot_servo(NULL, SERVO2, CAM_LEFT); break; */ rc5_change_servo2(-1); break; // verfaehrt Servo 2 um eine Stufe gegen den Uhrzeigersinn
 #endif
+		LOG_DEBUG("Testausgabe_Servo");
 #endif // BEHAVIOUR_SERVO_AVAILABLE
 
 		/* numerische Tasten */


### PR DESCRIPTION
Konfiguration ist wieder deckungsgleich wie develop-zweig (mit Ausnahme von LOG-Funktionen in ct-Bot.h Z33ff). Diese sind später wieder zu deaktivieren (--> MEMO).
