### PR TITLE
Experimental

### DIFF
--- a/include/bot-local-override.h
+++ b/include/bot-local-override.h
@@ -40,5 +40,4 @@
 //#undef PID_Kd
 //#define PID_Kd	20 /**< PID-Parameter differential */
 
-
 #endif /* INCLUDE_BOT_LOCAL_OVERRIDE_DUMMY_H_ */

--- a/include/bot-local.h
+++ b/include/bot-local.h
@@ -50,6 +50,7 @@
 #define BORDERSENSOR_POS_FW		DISTSENSOR_POS_FW		/**< Abgrundsensoren unter Distsensoren */
 #define BORDERSENSOR_POS_SW		(DISTSENSOR_POS_SW + 5)	/**< Abgrundsensoren 5 mm weiter aussen als Distsensoren */
 
+
 /*** einstellbare Parameter ***/
 
 /* Parameter der Motorregelung */
@@ -59,7 +60,7 @@
 #define PID_Ta				1	/**< Abtastzeit */
 #define PID_SHIFT			4	/**< Rechtsshift der Stellgroessenkorrektur */
 #define PID_TIME			333	/**< max. Aufrufinterval [ms] */
-#define PID_SPEED_THRESHOLD	BOT_SPEED_FOLLOW /**< Grenzgeschwindigkeit, ab der die Regelgroesse interpoliert wird */
+#define PID_SPEED_THRESHOLD	BOT_SPEED_FOLLOW	/**< Grenzgeschwindigkeit, ab der die Regelgroesse interpoliert wird */
 #define PWMMAX				511	/**< Maximaler PWM-Wert */
 #define PWMMIN				0	/**< Minimaler PWM-Wert */
 #define PWMSTART_L			100	/**< Basis-PWM-Wert linker Motor (falls keine dauerhaft gespeicherte PWM-LT vorhanden ist) */
@@ -77,14 +78,16 @@
 #define MOUSE_FULL_TURN	1600	/**< Mausaenderung in X-Richtung fuer einen vollen Kreis */
 #endif // PC
 
-#define WHEEL_DISTANCE	(WHEEL_TO_WHEEL_DIAMETER / 2.0f) /**< Abstand eines Rades zur Mitte des Bots [mm] */
+#define WHEEL_DISTANCE	(WHEEL_TO_WHEEL_DIAMETER / 2.0f)	/**< Abstand eines Rades zur Mitte des Bots [mm] */
 #define STUCK_DIFF		100		/**< ab welcher Differenz haben wir durchdrehende Raeder? */
 #define G_SPEED			0.5		/**< Kopplung Encoder- und Maussensor fuer Geschwindigkeiten (0.0=nur Radencoder, 1.0=nur Maussensor) */
 #define G_POS			0.5		/**< Kopplung Encoder- und Maussensor fuer Positionen und Winkel (0.0=nur Radencoder, 1.0=nur Maussensor) */
 
-#define BPS_NO_DATA			0xffff	/**< Wert des BPS-Sensors, falls keine Daten verfuegbar sind */
+#define BPS_NO_DATA		0xffff		/**< Wert des BPS-Sensors, falls keine Daten verfuegbar sind */
 
 /* System-Konstanten */
+/* --> Diese Änderungen sind mit lokalen Hardware-Anpassungen verbunden! */
+
 #define F_CPU	16000000L	/**< CPU-Frequenz [Hz] */
 //#define F_CPU	20000000L	/**< CPU-Frequenz [Hz] */
 #define XTAL	F_CPU		/**< CPU-Frequenz [Hz] */
@@ -94,25 +97,20 @@
 //#define UART_BAUD	230400	/**< Baudrate 230400 fuer UART-Kommunikation */
 //#define UART_BAUD	500000	/**< Baudrate 500000 fuer UART-Kommunikation */
 
-#define UART_LINUX_PORT		"/dev/ttyAMA0" /**< UART Port vom ARM-Linux-Board fuer Verbinung zum ATmega */
-#define BOT_RESET_GPIO		"/sys/class/gpio/gpio17/value" /**< Pfad zum Reset-GPIO vom ARM-Linux-Board */
-//#define ARM_LINUX_DISPLAY	"/dev/tty1" /**< Konsole fuer Display-Ausgaben auf ARM-Linux-Board. "stdout" fuer Ausgabe auf stdout */
+#define UART_LINUX_PORT		"/dev/ttyAMA0"	/**< UART Port vom ARM-Linux-Board fuer Verbinung zum ATmega */
+#define BOT_RESET_GPIO		"/sys/class/gpio/gpio17/value"	/**< Pfad zum Reset-GPIO vom ARM-Linux-Board */
+//#define ARM_LINUX_DISPLAY	"/dev/tty1"	/**< Konsole fuer Display-Ausgaben auf ARM-Linux-Board. "stdout" fuer Ausgabe auf stdout */
 
 #define EXPANSION_BOARD_AVAILABLE		/**< Erweiterungsmodul (MMC / WiPort) installiert */
 //#define EXPANSION_BOARD_MOD_AVAILABLE	/**< modifiziertes Erweiterungsmodul (MMC / WiPort) installiert */
 
-#if defined EXPANSION_BOARD_MOD_AVAILABLE
-#undef EXPANSION_BOARD_AVAILABLE	// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert EXPANSION_BOARD_AVAILABLE
-#undef MOUSE_AVAILABLE				// EXPANSION_BOARD_MOD_AVAILABLE deaktiviert MOUSE_AVAILABLE
-#endif // EXPANSION_BOARD_AVAILABLE
-
-//#define SPI_AVAILABLE		/**< verwendet den Hardware-SPI-Modus des Controllers, um mit der MMC zu kommunizieren. Muss ausserdem _immer_ an sein, wenn der Hardware-SPI-Umbau durchgefuehrt wurde! Hinweise in mcu/mmc.c beachten! */
+//#define SPI_AVAILABLE	/**< verwendet den Hardware-SPI-Modus des Controllers, um mit der MMC zu kommunizieren. Muss ausserdem _immer_ an sein, wenn der Hardware-SPI-Umbau durchgefuehrt wurde! Hinweise in mcu/mmc.c beachten! */
 
 /* Servo-Parameter */
 #ifndef __AVR_ATmega1284P__
 #if F_CPU == 16000000L
-#define DOOR_CLOSE 	7  		/**< Rechter Anschlag Servo 1 */
-#define DOOR_OPEN	14 		/**< Linker Anschlag Servo 1 */
+#define DOOR_CLOSE 	7		/**< Rechter Anschlag Servo 1 */
+#define DOOR_OPEN	14		/**< Linker Anschlag Servo 1 */
 #else
 #define DOOR_CLOSE 	10		/**< Rechter Anschlag Servo 1 */
 #define DOOR_OPEN	18		/**< Linker Anschlag Servo 1 */
@@ -138,7 +136,7 @@
 #define COL_FAR				400		/**< Fernbereich [mm] */
 
 /* Zustaende und Konstanten fuer das bot_solve_maze_behaviour-Verhalten */
-#define OPTIMAL_DISTANCE	(int16_t)(BOT_DIAMETER * 1.25f) /**< Optimale Distanz zur Wand [mm]. Etwas mehr als Bot-Durchmesser ist ideal (vergroessert aufgrund der Kennlinien der Sharps) */
+#define OPTIMAL_DISTANCE	(int16_t)(BOT_DIAMETER * 1.25f)	/**< Optimale Distanz zur Wand [mm]. Etwas mehr als Bot-Durchmesser ist ideal (vergroessert aufgrund der Kennlinien der Sharps) */
 #define ADJUST_DISTANCE		10		/**< Toleranzbereich [mm] */
 #define IGNORE_DISTANCE		240		/**< Entfernung, ab der eine Wand ignoriert wird [mm] */
 #define GROUND_GOAL			0x221	/**< Farbe des Zielpads */
@@ -163,5 +161,16 @@
 
 
 #include <bot-local-override.h>
+
+/************************************************************
+ * Some Dependencies!!!
+ ************************************************************/
+
+#ifdef EXPANSION_BOARD_MOD_AVAILABLE
+#undef EXPANSION_BOARD_AVAILABLE	// deaktiviert EXPANSION_BOARD_AVAILABLE
+#undef MOUSE_AVAILABLE				// deaktiviert MOUSE_AVAILABLE
+#endif // EXPANSION_BOARD_AVAILABLE
+
+/************************************************************/
 
 #endif // BOTLOCAL_H_

--- a/include/ena.h
+++ b/include/ena.h
@@ -33,8 +33,14 @@
 #define ENA_KANTLED			(1<<3)		/**< Enable-Leitung Angrundsensor */
 #define ENA_KLAPPLED		(1<<4)		/**< Enable-Leitung Schieberueberwachung */
 #define ENA_LINE			(1<<5)		/**< Enable-Leitung Liniensensor auf Mausplatine (ENA_MAUS im Schaltplan) */
+
+#ifdef EXPANSION_BOARD_MOD_AVAILABLE
+#define ENA_WIPORT			(1<<6)		/**< Enable-Leitung Reserve 1 */
+#define ENA_BPS				(1<<7)		/**< Enable-Leitung Reserve 2 */
+#else
 #define ENA_MMC				(1<<6)		/**< Enable-Leitung Reserve 1 */
 #define ENA_MOUSE_SENSOR	(1<<7)		/**< Enable-Leitung Reserve 2 */
+#endif // EXPANSION_BOARD_MOD_AVAILABLE
 
 #ifndef __ASSEMBLER__
 

--- a/mcu/ena.c
+++ b/mcu/ena.c
@@ -90,11 +90,9 @@ void ENA_on(uint8_t enable) {
 		ena &= (uint8_t) (~enable);	// CS der MMC und SCLK fuer Maus haengen an not-Q der FlipFlops!
 	} else
 #endif // EXPANSION_BOARD_AVAILABLE
-
 	{
 		ena |= enable;
 	}
-
 	ENA_set(ena);
 
 #ifdef EXPANSION_BOARD_AVAILABLE
@@ -109,20 +107,6 @@ void ENA_on(uint8_t enable) {
 #endif // SPI_AVAILABLE
 	}
 #endif // EXPANSION_BOARD_AVAILABLE
-
-#ifdef EXPANSION_BOARD_MOD_AVAILABLE
-	//	if ((enable & (ENA_ERW2 | ENA_ERW1)) != 0) {
-	//		/* Flipflops takten */
-	//		PORTD |= _BV(PD2);
-	//		PORTD = (uint8_t) (PORTD & ~_BV(PD2));
-	//#ifdef SPI_AVAILABLE
-	//		if (enable == ENA_ERW1) {
-	//			SPCR |= _BV(SPE) | _BV(MSTR); // SPI an
-	//		}
-	//#endif // SPI_AVAILABLE
-	//	}
-#endif // EXPANSION_BOARD_MOD_AVAILABLE
-
 }
 
 /**


### PR DESCRIPTION
1) Corrected turn-direction for Servo2: VOL+ --> clockwise & VOL- --> counterclockwise
2) Moved local hardware changes to bot-local-override.h
3) Introduced section for module switches in bot-local.h
4) Minor formatting improvements (readability) (TAB-spacing)
5) Defined new ENA names for EXPANSION_BOARD_MOD_AVAILABLE
6) Removed unused section for EXPANSION_BOARD_MOD_AVAILABLE in ena.c

Tested code on local bot.
Bug-report from previous dev-version (without these changes): Servo1 is not turning back again after door is in state "open".
