### PR TITLE
Maintenance Update

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -50,16 +50,6 @@
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 		</extension>
 	</configuration>
-	<configuration id="cdt.managedbuild.config.gnu.exe.debug.2039935845.312441075.1247540867.665793659.45794498" name="Debug-ARM-Linux-RPi2">
-		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
-			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="true" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -mcpu=cortex-a7 -mtune=cortex-a7 -mfloat-abi=hard -mfpu=vfpv4 -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true" store-entries-with-project="false">
-				<language-scope id="org.eclipse.cdt.core.gcc"/>
-				<language-scope id="org.eclipse.cdt.core.g++"/>
-			</provider>
-			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-		</extension>
-	</configuration>
 	<configuration id="cdt.managedbuild.config.gnu.exe.debug.2039935845.312441075.1247540867.665793659.45794498.48681013" name="Debug-ARM-Linux-RPi3">
 		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -30,6 +30,18 @@ Die Wertebereiche liegen im Einzelnen bei:
 
 * Den Datentyp char solltest du ebenfalls nur verwenden, wenn es sich wirklich um ein Zeichen handelt. Ansonsten verwende bitte ebenfalls uint8_t oder int8_t.
 
+* von den beiden vorherigen Punkten sind, neben einzelnen Aufrufen von *int* im Code die gesondert kommentiert sind, die folgenden Dateien ausgenommen: 
+
+  * ct-bot.c & ct-bot.h
+  * global.h
+  * tcp_pc.c & tcp.h	(Kommunikation mit OS)
+  * tcp-server_pc.c & tcp-server.h	(Kommunikation mit OS)
+  * uart.c, uart_pc.c & uart.h	(Kommunikation mit OS)
+  * uart-test_pc.c	(Kommunikation mit OS)
+  * network.c & lwneuralnet.h	(da externe Library)
+  * alle Dateien im Verzeichnis /mcu/SdFat	(da externe Library)
+  
+
 * Bei Programmieren von Verhaltensweisen für das c't-Bot-Framework gilt folgende Konvention:
   * Verhaltensweisen (Behaviours), die vom Framework bearbeitet werden, heißen bot_*xxx*_behaviour.
   * Die Botenfunktionen, die solche Verhaltensweisen aufrufen und aktivieren, heißen bot_*xxx*.

--- a/command.c
+++ b/command.c
@@ -863,10 +863,8 @@ int8_t command_evaluate(void) {
 						const uint16_t block = (uint16_t) done / SD_BLOCK_SIZE;
 #if defined __AVR_ATmega1284P__ || defined PC
 						if (block > 6) {
-#elif defined MCU_ATMEGA644X
+#else // MCU_ATMEGA644X
 						if (block > 2) {
-#else // ATmega32
-						if (block > 0) {
 #endif // MCU-Typ
 							break;
 						}

--- a/include/bot-local.h
+++ b/include/bot-local.h
@@ -109,8 +109,8 @@
 #define G_POS			0.5f		/**< Kopplung Encoder- und Maussensor fuer Positionen und Winkel (0.0=nur Radencoder, 1.0=nur Maussensor) */
 
 /* Servo-Parameter */
-#define DOOR_CLOSE 	65	/**< Rechter Anschlag Servo 1 (fuer ATmega32/644: Schrittweite 18, Offset 7) */
-#define DOOR_OPEN	185	/**< Linker Anschlag Servo 1 (fuer ATmega32/644: Schrittweite 18, Offset 7) */
+#define DOOR_CLOSE 	65	/**< Rechter Anschlag Servo 1 (fuer ATmega644: Schrittweite 18, Offset 7) */
+#define DOOR_OPEN	185	/**< Linker Anschlag Servo 1 (fuer ATmega644: Schrittweite 18, Offset 7) */
 #define CAM_LEFT 	10	/**< Rechter Anschlag Servo 2 */
 #define CAM_RIGHT	250	/**< Linker Anschlag Servo 2 */
 #define CAM_CENTER	120	/**< Mittelstellung Servo 2 */

--- a/mcu/bootloader.c
+++ b/mcu/bootloader.c
@@ -60,10 +60,7 @@
 #define DEVTYPE     DEVTYPE_ISP		/**< Device-Typ des emulierten Programmers */
 
 /* Boot Size in Words */
-#if defined __AVR_ATmega32__ // => Fuse Bits: low: 0xFF, high: 0xDC
-#define BOOTSIZE 512		// => Linker-Settings: -Wl,--section-start=.bootloader=0x7C00
-//#warning "Bitte pruefen, ob der Linker auch mit den Optionen: -Wl,--section-start=.bootloader=0x7C00 startet "
-#elif defined MCU_ATMEGA644X // => Fuse Bits: low: 0xFF, high: 0xDC, Ext'd: 0xFF
+#if defined MCU_ATMEGA644X // => Fuse Bits: low: 0xFF, high: 0xDC, Ext'd: 0xFF
 #define BOOTSIZE 1024		// => Linker-Settings: -Wl,--section-start=.bootloader=0xF800
 //#warning "Bitte pruefen, ob der Linker auch mit den Optionen: -Wl,--section-start=.bootloader=0xF800 startet"
 #elif defined __AVR_ATmega1284P__ // => Fuse Bits: low: 0xFF, high: 0xDC, Ext'd: 0xFF
@@ -121,29 +118,7 @@ typedef uint16_t pagebuf_t; /**< Seitengroesse */
 typedef uint8_t pagebuf_t; /**< Seitengroesse */
 #endif
 
-#if defined(__AVR_ATmega32__)
-/* Part-Code ISP */
-#define DEVTYPE_ISP     0x72
-/* Part-Code Boot */
-#define DEVTYPE_BOOT    0x73
-
-#define SIG_BYTE1	0x1E
-#define SIG_BYTE2	0x95
-#define SIG_BYTE3	0x02
-
-#define UART_BAUD_HIGH	UBRRH
-#define UART_BAUD_LOW	UBRRL
-#define UART_STATUS	UCSRA
-#define UART_TXREADY	UDRE
-#define UART_RXREADY	RXC
-#define UART_DOUBLE	U2X
-#define UART_CTRL	UCSRB
-#define UART_CTRL_DATA	((1<<TXEN) | (1<<RXEN))
-#define UART_CTRL2	UCSRC
-#define UART_CTRL2_DATA	((1<<URSEL) | (1<<UCSZ1) | (1<<UCSZ0))
-#define UART_DATA	UDR
-
-#elif defined(__AVR_ATmega644__)
+#if defined(__AVR_ATmega644__)
 /* Part-Code ISP */
 #define DEVTYPE_ISP     0x74
 /* Part-Code Boot */

--- a/mcu/init-low.c
+++ b/mcu/init-low.c
@@ -100,14 +100,6 @@ void init_before_main(void) {
 	/* Statusregister sichern */
     mcucsr = MCUSR;
     MCUSR = 0;
-#elif defined __AVR_ATmega32__
-	MCUCSR = (uint8_t) (MCUCSR & ~_BV(WDRF));
-	WDTCR |= _BV(WDTOE) | _BV(WDE);
-	WDTCR = 0;
-
-	/* Statusregister sichern */
-	mcucsr = MCUCSR;
-	MCUCSR = 0;
 #else
 #error "Nicht unterstuetzter MCU-Typ"
 #endif // MCU-Typ

--- a/mcu/motor-low.c
+++ b/mcu/motor-low.c
@@ -59,8 +59,8 @@
 #define PWM_TOP (uint16_t)((float) F_CPU / 2.f / PWM_FREQUENCY)
 
 
-/* PWM fuer Servos (ATmega32 / ATmega644(p)) */
-#define PWM_CLK_0 (_BV(CS02) | _BV(CS00)) /**< Prescaler fuer PWM0 = 1024 -> ATmega32/644(p) 16 MHz: 30.64 Hz; ATmega644(p) 20 MHz: 38.30 Hz */
+/* PWM fuer Servos (ATmega644(p)) */
+#define PWM_CLK_0 (_BV(CS02) | _BV(CS00)) /**< Prescaler fuer PWM0 = 1024 -> ATmega644(p) 16 MHz: 30.64 Hz; ATmega644(p) 20 MHz: 38.30 Hz */
 
 
 int16_t motor_left;  /**< zuletzt gestellter Wert linker Motor */
@@ -283,22 +283,13 @@ void servo_low(uint8_t servo, uint8_t pos) {
 			TIMSK3 |= (uint8_t) (_BV(TOIE3) | _BV(OCIE3B)); // Overflow Interrupt Enable, Output Compare B Match Interrupt Enable
 		}
 	}
-#else // ! __AVR_ATmega1284P__
+#else // ! __AVR_ATmega1284P__ but __AVR_ATmega644X__
 	if (servo == SERVO1) {
 		if (pos == SERVO_OFF) {
-#ifdef MCU_ATMEGA644X
 			TCCR0B = (uint8_t) (TCCR0B & ~PWM_CLK_0); // PWM0 aus
-#else
-			TCCR0 = (uint8_t) (TCCR0 & ~PWM_CLK_0); // PWM0 aus
-#endif // MCU_ATMEGA644X
 		} else {
-#ifdef MCU_ATMEGA644X
 			TCCR0B |= PWM_CLK_0; // PWM0 an; ATmega644(p) 16 MHz: 30.64 Hz -> T = 32.640 ms; 20 MHz: 38.15 Hz -> T = 26.112 ms
 			OCR0A = (uint8_t) servo_calc_ocr(pos);
-#else
-			TCCR0 |= PWM_CLK_0; // PWM0 an; ATmega32 16 MHz: 30.64 Hz -> T = 32.640 ms
-			OCR0 = (uint8_t) servo_calc_ocr(pos);
-#endif // MCU_ATMEGA644X
 		}
 	}
 #endif // __AVR_ATmega1284P__

--- a/sensor.c
+++ b/sensor.c
@@ -419,7 +419,7 @@ void sensor_update(void) {
 		x_pos = (int16_t) (G_POS * x_mou + (1.f - G_POS) * x_enc);
 		y_pos = (int16_t) (G_POS * y_mou + (1.f - G_POS) * y_enc);
 		/* Korrektur, falls mou und enc zu unterschiedlichen Seiten zeigen */
-		if (fabsf(heading_mou - heading_enc) > 180.f) {
+		if ((float) fabsf(heading_mou - heading_enc) > 180.f) {
 			/* wir nutzen zum Rechnen zwei Drehrichtungen */
 			heading = heading_mou <= 180.f ? heading_mou * G_POS : (heading_mou - 360.f) * G_POS;
 			heading += heading_enc <= 180.f ? heading_enc * (1.f - G_POS) : (heading_enc - 360.f) * (1.f - G_POS);


### PR DESCRIPTION
Removed remnants of ATmega32 MCU target. Updated coding conventions. Fixed warning -Wdouble-promotion for fmodf() & fabsf() (AVR).